### PR TITLE
Changed the Firely codegenerator to correct a few mistakes

### DIFF
--- a/generated/.gitignore
+++ b/generated/.gitignore
@@ -1,0 +1,1 @@
+/Generated/


### PR DESCRIPTION
Running the unit-tests showed a few minor mistakes:
* There should be a `[FhirType(...)]` attribute on DomainResource (inconsistent, but that's how it is ;-)
* The `/// <summary>` comments at the end of the file triggered warnings
* `ModelInfo.SupportedResources` should not contain `DomainResource`
* The validation patterns (like `[OidPattern]`) should be put on the `Value` element of the FHIR primitive types, instead they were generated on all elements using those primitves.
* `ModelInfo.FhirCsTypeToString()` should contain the type "xhtml".

Must admit I have not yet run this against R2 and R4.  R4 is up next.
