### PR TITLE
fix: Path to generated ts files in test config

### DIFF
--- a/test/TypeScript_R2/tsconfig.json
+++ b/test/TypeScript_R2/tsconfig.json
@@ -16,6 +16,6 @@
       "noEmit": true
   },
   "files": [
-      "../../generated/R2.ts"
+      "../../generated/TypeScript_R2.ts"
   ]
 }

--- a/test/TypeScript_R3/tsconfig.json
+++ b/test/TypeScript_R3/tsconfig.json
@@ -16,6 +16,6 @@
       "noEmit": true
   },
   "files": [
-      "../../generated/R3.ts"
+      "../../generated/TypeScript_R3.ts"
   ]
 }

--- a/test/TypeScript_R4/tsconfig.json
+++ b/test/TypeScript_R4/tsconfig.json
@@ -16,6 +16,6 @@
       "noEmit": true
   },
   "files": [
-      "../../generated/R4.ts"
+      "../../generated/TypeScript_R4.ts"
   ]
 }

--- a/test/TypeScript_R5/tsconfig.json
+++ b/test/TypeScript_R5/tsconfig.json
@@ -16,6 +16,6 @@
       "noEmit": true
   },
   "files": [
-      "../../generated/R5.ts"
+      "../../generated/TypeScript_R5.ts"
   ]
 }


### PR DESCRIPTION
Unsure if this was intentional, but running the TypeScript tests locally failed since the path in tsconfig.json to the generated TypeScript files was lacking 'TypeScript_'.