### PR TITLE
Improve FHIR metadata conversion

### DIFF
--- a/src/Microsoft.Health.Fhir.SpecManager/Converters/FromR3.cs
+++ b/src/Microsoft.Health.Fhir.SpecManager/Converters/FromR3.cs
@@ -496,28 +496,22 @@ namespace Microsoft.Health.Fhir.SpecManager.Converters
                     ProcessDataTypePrimitive(sd, fhirVersionInfo);
                     break;
 
-                case "complex-type":
-                    if ((sd.Derivation == "constraint") &&
-                        (sd.Type != "Quantity"))
-                    {
-                        ProcessComplex(sd, fhirVersionInfo, FhirComplex.FhirComplexType.Extension);
-                    }
-                    else
-                    {
-                        ProcessComplex(sd, fhirVersionInfo, FhirComplex.FhirComplexType.DataType);
-                    }
-
-                    break;
-
                 case "resource":
-                    if ((sd.Derivation == "constraint") &&
-                        (sd.Type != "Quantity"))
+                case "complex-type":
+                    if (sd.Derivation == "constraint")
                     {
-                        ProcessComplex(sd, fhirVersionInfo, FhirComplex.FhirComplexType.Extension);
+                        if (sd.Type == "Extension")
+                        {
+                            ProcessComplex(sd, fhirVersionInfo, FhirComplex.FhirComplexType.Extension);
+                        }
+                        else
+                        {
+                            ProcessComplex(sd, fhirVersionInfo, FhirComplex.FhirComplexType.Profile);
+                        }
                     }
                     else
                     {
-                        ProcessComplex(sd, fhirVersionInfo, FhirComplex.FhirComplexType.Resource);
+                        ProcessComplex(sd, fhirVersionInfo, sd.Kind == "complex-type" ? FhirComplex.FhirComplexType.DataType : FhirComplex.FhirComplexType.Resource);
                     }
 
                     break;

--- a/src/Microsoft.Health.Fhir.SpecManager/Converters/FromR4.cs
+++ b/src/Microsoft.Health.Fhir.SpecManager/Converters/FromR4.cs
@@ -501,28 +501,22 @@ namespace Microsoft.Health.Fhir.SpecManager.Converters
                     ProcessDataTypePrimitive(sd, fhirVersionInfo);
                     break;
 
-                case "complex-type":
-                    if ((sd.Derivation == "constraint") &&
-                        (sd.Type != "Quantity"))
-                    {
-                        ProcessComplex(sd, fhirVersionInfo, FhirComplex.FhirComplexType.Extension);
-                    }
-                    else
-                    {
-                        ProcessComplex(sd, fhirVersionInfo, FhirComplex.FhirComplexType.DataType);
-                    }
-
-                    break;
-
                 case "resource":
-                    if ((sd.Derivation == "constraint") &&
-                        (sd.Type != "Quantity"))
+                case "complex-type":
+                    if (sd.Derivation == "constraint")
                     {
-                        ProcessComplex(sd, fhirVersionInfo, FhirComplex.FhirComplexType.Extension);
+                        if (sd.Type == "Extension")
+                        {
+                            ProcessComplex(sd, fhirVersionInfo, FhirComplex.FhirComplexType.Extension);
+                        }
+                        else
+                        {
+                            ProcessComplex(sd, fhirVersionInfo, FhirComplex.FhirComplexType.Profile);
+                        }
                     }
                     else
                     {
-                        ProcessComplex(sd, fhirVersionInfo, FhirComplex.FhirComplexType.Resource);
+                        ProcessComplex(sd, fhirVersionInfo, sd.Kind == "complex-type" ? FhirComplex.FhirComplexType.DataType : FhirComplex.FhirComplexType.Resource);
                     }
 
                     break;

--- a/src/Microsoft.Health.Fhir.SpecManager/Converters/FromR4.cs
+++ b/src/Microsoft.Health.Fhir.SpecManager/Converters/FromR4.cs
@@ -634,8 +634,15 @@ namespace Microsoft.Health.Fhir.SpecManager.Converters
             elementTypes = new Dictionary<string, FhirElementType>();
             regex = string.Empty;
 
+            /* Correct some mistakes in the spec. Need to discuss this with Gino.
+             */
+            if (element.Path == "Resource.id")
+            {
+                elementTypes.Add("id", new FhirElementType("id"));
+            }
+
             // check for declared type
-            if (element.Type != null)
+            else if (element.Type != null)
             {
                 foreach (fhir_4.ElementDefinitionType edType in element.Type)
                 {

--- a/src/Microsoft.Health.Fhir.SpecManager/Converters/FromR5.cs
+++ b/src/Microsoft.Health.Fhir.SpecManager/Converters/FromR5.cs
@@ -502,28 +502,22 @@ namespace Microsoft.Health.Fhir.SpecManager.Converters
                     ProcessDataTypePrimitive(sd, fhirVersionInfo);
                     break;
 
-                case "complex-type":
-                    if ((sd.Derivation == "constraint") &&
-                        (sd.Type != "Quantity"))
-                    {
-                        ProcessComplex(sd, fhirVersionInfo, FhirComplex.FhirComplexType.Extension);
-                    }
-                    else
-                    {
-                        ProcessComplex(sd, fhirVersionInfo, FhirComplex.FhirComplexType.DataType);
-                    }
-
-                    break;
-
                 case "resource":
-                    if ((sd.Derivation == "constraint") &&
-                        (sd.Type != "Quantity"))
+                case "complex-type":
+                    if (sd.Derivation == "constraint")
                     {
-                        ProcessComplex(sd, fhirVersionInfo, FhirComplex.FhirComplexType.Extension);
+                        if (sd.Type == "Extension")
+                        {
+                            ProcessComplex(sd, fhirVersionInfo, FhirComplex.FhirComplexType.Extension);
+                        }
+                        else
+                        {
+                            ProcessComplex(sd, fhirVersionInfo, FhirComplex.FhirComplexType.Profile);
+                        }
                     }
                     else
                     {
-                        ProcessComplex(sd, fhirVersionInfo, FhirComplex.FhirComplexType.Resource);
+                        ProcessComplex(sd, fhirVersionInfo, sd.Kind == "complex-type" ? FhirComplex.FhirComplexType.DataType : FhirComplex.FhirComplexType.Resource);
                     }
 
                     break;

--- a/src/Microsoft.Health.Fhir.SpecManager/Converters/FromR5.cs
+++ b/src/Microsoft.Health.Fhir.SpecManager/Converters/FromR5.cs
@@ -11,7 +11,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
-using Microsoft.Health.Fhir.SpecManager.fhir.r2;
 using Microsoft.Health.Fhir.SpecManager.Manager;
 using Microsoft.Health.Fhir.SpecManager.Models;
 using Newtonsoft.Json;
@@ -628,6 +627,7 @@ namespace Microsoft.Health.Fhir.SpecManager.Converters
         /// <param name="regex">        [out] The RegEx.</param>
         /// <returns>True if it succeeds, false if it fails.</returns>
         private static bool TryGetTypeFromElement(
+
             string structureName,
             fhir_5.ElementDefinition element,
             out Dictionary<string, FhirElementType> elementTypes,
@@ -636,8 +636,15 @@ namespace Microsoft.Health.Fhir.SpecManager.Converters
             elementTypes = new Dictionary<string, FhirElementType>();
             regex = string.Empty;
 
+            /* Correct some mistakes in the spec. Need to discuss this with Gino.
+             */
+            if (element.Path == "Resource.id")
+            {
+                elementTypes.Add("id", new FhirElementType("id"));
+            }
+
             // check for declared type
-            if (element.Type != null)
+            else if (element.Type != null)
             {
                 foreach (fhir_5.ElementDefinitionType edType in element.Type)
                 {


### PR DESCRIPTION
This PR contains some improvements to the StructureDefinition->FhirR3/4/5 conversions:

* It corrects the Element.id primitive type from 'string' to 'id' (incorrect in the StructureDefinitions)
* It introduces a better separation between extensions and extensions/profiles.

This is in preparation of a PR for the 2.0-API update to the Firely generator.