### PR TITLE
Language options are now case insensitive

### DIFF
--- a/src/Microsoft.Health.Fhir.SpecManager/Manager/ExporterOptions.cs
+++ b/src/Microsoft.Health.Fhir.SpecManager/Manager/ExporterOptions.cs
@@ -5,9 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
-using Microsoft.Health.Fhir.SpecManager.Models;
-using static Microsoft.Health.Fhir.SpecManager.Models.FhirTypeBase;
 
 namespace Microsoft.Health.Fhir.SpecManager.Manager
 {
@@ -79,7 +76,7 @@ namespace Microsoft.Health.Fhir.SpecManager.Manager
             }
             else
             {
-                _languageOptions = new Dictionary<string, string>();
+                _languageOptions = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
             }
 
             ServerUrl = fhirServerUrl;

--- a/src/fhir-codegen-cli/Program.cs
+++ b/src/fhir-codegen-cli/Program.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using Microsoft.Health.Fhir.SpecManager.Extensions;
 using Microsoft.Health.Fhir.SpecManager.Language;
 using Microsoft.Health.Fhir.SpecManager.Manager;
 using Microsoft.Health.Fhir.SpecManager.Models;
@@ -342,7 +341,7 @@ namespace FhirCodegenCli
 
             foreach (ILanguage lang in languages)
             {
-                optionsByLanguage.Add(lang.LanguageName, new Dictionary<string, string>());
+                optionsByLanguage.Add(lang.LanguageName, new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase));
             }
 
             if (string.IsNullOrEmpty(languageOptions))


### PR DESCRIPTION
The language option `subset` was not read because of case problems. By setting the dictionary to `InvariantCultureIgnoreCase` this problem does not arise anymore.