### PR TITLE
fix(TS): valueset checks on array members

### DIFF
--- a/languageInput/TypeScriptSdk/additional-files/fhir/FhirBase.ts
+++ b/languageInput/TypeScriptSdk/additional-files/fhir/FhirBase.ts
@@ -269,7 +269,7 @@ export class FhirBase {
 
     (this as any)[p].forEach((x:any,i:number) => {
       iss.push(...x.doModelValidation(`${exp}.${p}[${i}]`));
-      if (!(this as any)[p].hasCodingFromValidationObj(vsV)) {
+      if (!x.hasCodingFromValidationObj(vsV)) {
         iss.push({
           severity: (vsS === 'r') ? 'error' : 'information', 
           code:'code-invalid', 


### PR DESCRIPTION
Currently trying to validate an `OperationDefinition` like https://www.hl7.org/fhir/operationdefinition-example.json will fail because the valueset test is run against the array of `OperationDefinition.resource` values rather than its entries.

Would be good to include parsing tests for fhir-typescript from spec artifacts to make sure validating core spec artifacts doesn't generate errors.