### PR TITLE
OCI/Docker-based build and runtime support.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.dockerignore
+.git
+.gitignore
+.editorconfig
+
+docfx
+Dockerfile
+generated
+LICENSE
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/dotnet/sdk:6.0
+LABEL maintainer="Preston Lee"
+
+WORKDIR /app
+
+COPY . .
+
+RUN dotnet build
+
+ENTRYPOINT [ "dotnet", "run", "--project", "src/fhir-codegen-cli", "--" ]

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The system is designed to allow developers to add additional languages to be exp
 
 ## Build and Running From OCI (i.e. Docker) Images
 
-If you do not have .NET installed and wish to use the command-line utilities, you may instead build an OCI container to run it for you. The included [Dockerfile](./Dockerfile) has been tested with Docker Desktop but should work also with buildah and container runtimes such as cri-o. To build your own image for your native CPU architecture:
+If you do not have .NET installed and wish to use the command-line utilities, you may instead build an OCI container to run it for you. The included [Dockerfile](./Dockerfile) has been tested with Docker Desktop but should work also with `buildah` and container runtimes such as `podman` and `cri-o`. To build your own image for your native CPU architecture:
 
   `docker build -t <whatever>/fhir-codegen:latest .`
 
@@ -182,9 +182,9 @@ Alternatively, to build and push for multiple CPU architectures,
 
 The image is configured to run the CLI as its default entry point. To generate FHIR 4.0.1 TypeScript interfaces to a file on your _host_ computer's ./out directory, for example, simply pass the arguments as input to the container runtime, like so:
 
-  `docker run -it --rm -v `pwd`/out:/out <whatever>/fhir-codegen:latest --load-r4 4.0.1 --language TypeScript --output-path /out`
+  ``docker run -it --rm -v `pwd`/out:/out <whatever>/fhir-codegen:latest --load-r4 4.0.1 --language TypeScript --output-path /out``
 
-The above command binds a ./out directory (in your current working directory) to the output directory of fhir-codegen-cli running within the container, so you output will persist after the container exits and is removed. 
+The above command binds an ./out directory (within your current working directory) to the output directory of fhir-codegen-cli running within the container, so you output will persist after the container exits and is removed. 
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,22 @@ The `generated` directory has static outputs for each of the supported versions 
 
 The system is designed to allow developers to add additional languages to be exported.  For more information, please see the [documentation](http://microsoft.github.io/fhir-codegen/).
 
+## Build and Running From OCI (i.e. Docker) Images
+
+If you do not have .NET installed and wish to use the command-line utilities, you may instead build an OCI container to run it for you. The included [Dockerfile](./Dockerfile) has been tested with Docker Desktop but should work also with buildah and container runtimes such as cri-o. To build your own image for your native CPU architecture:
+
+  `docker build -t <whatever>/fhir-codegen:latest .`
+
+Alternatively, to build and push for multiple CPU architectures,
+
+  `docker buildx build --platform linux/arm64,linux/amd64 --push -t <whatever>/fhir-codegen:latest .`
+
+The image is configured to run the CLI as its default entry point. To generate FHIR 4.0.1 TypeScript interfaces to a file on your _host_ computer's ./out directory, for example, simply pass the arguments as input to the container runtime, like so:
+
+  `docker run -it --rm -v `pwd`/out:/out <whatever>/fhir-codegen:latest --load-r4 4.0.1 --language TypeScript --output-path /out`
+
+The above command binds a ./out directory (in your current working directory) to the output directory of fhir-codegen-cli running within the container, so you output will persist after the container exits and is removed. 
+
 # Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a


### PR DESCRIPTION
I've put up some test builds at https://hub.docker.com/repository/docker/graphitehealth/fhir-codegen but left it generic in the included README patch. We have a lot of M1/M2 chip users, so cross-architecture for both ARMv8 and x64 is important to us internally.

I'm not familiar with how to optimally do multi-stage (build stage + runtime stage) builds for .NET projects to make the distributable image sizes not stupidly large, and could use some help with that! Ideally it would be the equivalent of however .NET projects do this: https://github.com/preston/angular-on-fhir/blob/master/Dockerfile

