### PR TITLE
Add known version support for hl7.fhir.r5.core release 5.0.0

### DIFF
--- a/src/Microsoft.Health.Fhir.SpecManager/Manager/FhirPackageCommon.cs
+++ b/src/Microsoft.Health.Fhir.SpecManager/Manager/FhirPackageCommon.cs
@@ -87,6 +87,7 @@ public static class FhirPackageCommon
         new (FhirSequenceEnum.R5,    new DateOnly(2022, 09, 10), "5.0.0-ballot",      "R5 Ballot #1"),
         new (FhirSequenceEnum.R5,    new DateOnly(2022, 12, 14), "5.0.0-snapshot3",   "R5 Connectathon 32 Base"),
         new (FhirSequenceEnum.R5,    new DateOnly(2023, 03, 01), "5.0.0-draft-final", "R5 Final QA"),
+        new (FhirSequenceEnum.R5,    new DateOnly(2023, 03, 26), "5.0.0",             "R5 Release"),
     };
 
     /// <summary>(Immutable) The ballot URL changeover date.</summary>

--- a/src/Microsoft.Health.Fhir.SpecManager/PackageManager/FhirCacheService.cs
+++ b/src/Microsoft.Health.Fhir.SpecManager/PackageManager/FhirCacheService.cs
@@ -210,7 +210,7 @@ public class FhirCacheService : IDisposable
     {
         foreach (Uri registryUri in PackageRegistryUris)
         {
-            Uri uri = new Uri(registryUri, $"{name}/{version}/");
+            Uri uri = new Uri(registryUri, $"{name}/{version}");
             directory = Path.Combine(_cachePackageDirectory, $"{name}#{version}");
 
             string directive = name + "#" + version;

--- a/src/Microsoft.Health.Fhir.SpecManager/PackageManager/RegistryPackageManifest.cs
+++ b/src/Microsoft.Health.Fhir.SpecManager/PackageManager/RegistryPackageManifest.cs
@@ -61,7 +61,8 @@ public class RegistryPackageManifest
                     bool remove = false;
                     string name = manifest.Versions[key].Name;
 
-                    if (manifest.Versions[key].PackageKind == "??")
+                    if (string.IsNullOrEmpty(manifest.Versions[key].PackageKind) ||
+                        (manifest.Versions[key].PackageKind == "??"))
                     {
                         if (name.StartsWith("hl7.fhir.r", StringComparison.OrdinalIgnoreCase))
                         {
@@ -73,7 +74,8 @@ public class RegistryPackageManifest
                         }
                     }
 
-                    if (manifest.Versions[key].FhirVersion == "??")
+                    if (string.IsNullOrEmpty(manifest.Versions[key].FhirVersion) ||
+                        (manifest.Versions[key].FhirVersion == "??"))
                     {
                         if (manifest.Versions[key].PackageKind.Equals("core", StringComparison.OrdinalIgnoreCase) &&
                             FhirPackageCommon.TryGetMajorReleaseForVersion(key, out sequence))


### PR DESCRIPTION
Core: added 5.0 release
Core: Fix for packages2.fhir.org index URL.
Core: Fix for missing PackageKind in package.fhir.org manifests.